### PR TITLE
Update app ready wait for Electron 13

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports = async function serveNextAt(uri, options = {}) {
   ]);
 
   // Wait for app to be ready
-  app.once("ready", () => {
+  app.whenReady().then(() => {
     if (dev) {
       if (isNaN(port)) {
         const error = new Error(


### PR DESCRIPTION
I was upgrading an Electron app from version `12.2.1` to `13.5.1`. I noticed some issues with the `next-electron-server` not starting. After some investigation, I was able to fix the issue locally by using `app.whenReady()` instead of `app.once("ready")`.

I'm not 100% sure why this fix works, or why Electron 13 broke it! From [the description of `app.whenReady()`](https://www.electronjs.org/docs/api/app#appwhenready) in the Electron docs, it seems like this is its intended use:

> Returns `Promise<void>` - fulfilled when Electron is initialized. May be used as a convenient alternative to checking `app.isReady()` and subscribing to the `ready` event if the app is not ready yet.

Maybe in Electron 13 you can't register `app.once` if the app isn't ready yet?